### PR TITLE
Fix outdated mention to "breeze_themes" in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ int main()
 
     // Need to initialize the resource, since we're using an external
     // build system and this isn't automatically handled by CMake.
-    Q_INIT_RESOURCE(breeze_themes);
+    Q_INIT_RESOURCE(breeze);
     QFile file(":/dark-green/stylesheet.qss");
     file.open(QFile::ReadOnly | QFile::Text);
     QTextStream stream(&file);


### PR DESCRIPTION
Currently, in the README, the listed load mechanism through CMake is to `Q_INIT_RESOURCE` "breeze_themes", which will fail using the provided CMake file as the linked ".qrc" is actually "breeze.qrc".

This caused me a bit of a head scratch while setting up, as the CMake target library is indeed called breeze_themes, but the name to initialise does not appear to be that, instead the name of the .qrc.

This PR simply changes that line to read the value that will successfully compile.