### PR TITLE
Add support for auto-detecting the system theme.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "*.qss.in": "qss",
+        "*.svg.in": "xml",
+        "stdexcept": "cpp"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ BreezeStyleSheets is a set of beautiful light and dark stylesheets that render c
 
 - [Gallery](#gallery)
 - [Customization](#customization)
+- [Examples](#examples)
 - [Features](#features)
   - [Extensions](#extensions)
 - [Extending Stylesheets](#extending-stylesheets)
@@ -183,6 +184,18 @@ python configure.py --extensions=advanced-docking-system --resource custom.qrc
 ```
 
 Like with styles, `--extensions` takes a comma-separated list of values, or `all`, which will add every extension present in the [extensions](/extension) directory. For a detailed introduction to creating your own extensions, see the extensions [tutorial](/extension/README.md).
+
+# Examples
+
+Many examples of widgets using [custom themes](/example/widgets.py), including with the [Advanced Docking System](/example/advanced-dock.py), [custom icons](/example/standard_icons.py), and [titlebars](/example/titlebar.py) can be found in the [example](/example/) directory.
+
+The support stylesheets include:
+- `dark`
+- `light`
+- `auto`
+- `native` (the system native theme)
+
+And any `-purple`, `-green`, etc. variants can also be used. `auto` will automatically detect if the system theme is light or dark and select the correct theme accordingly.
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The support stylesheets include:
 - `auto`
 - `native` (the system native theme)
 
-And any `-purple`, `-green`, etc. variants can also be used. `auto` will automatically detect if the system theme is light or dark and select the correct theme accordingly.
+And any `-purple`, `-green`, etc. variants can also be used. `auto` will automatically detect if the system theme is light or dark and select the correct theme accordingly. The cross-platform way to detect the correct theme is using `get_theme` in either [Python](/example/breeze_theme.py) or [C++](/example/breeze_theme.hpp). Just include those stand-alone files in your project and you can select the desired theme based on the user's profile settings at startup.
 
 # Features
 

--- a/example/breeze_theme.hpp
+++ b/example/breeze_theme.hpp
@@ -1,0 +1,464 @@
+/**
+ *  breeze_theme
+ *  ============
+ *
+ *  Determine if the system theme is light or dark, supporting many platforms.
+ *
+ *  This code has been minimally tested but should be useful on most platforms.
+ *  This makes extensive use of C++17 features. On Windows, this requires adding
+ *  `OleAut32.lib` to the linker.
+ *
+ *  This currently supports:
+ *  - Windows
+ *  - Linux
+ *
+ *  Enhancements for macOS would be greatly appreciated.
+ *
+ *  This is subject to the following license terms:
+ *
+ *  darkdetect
+ *  ==========
+ *  https://github.com/albertosottile/darkdetect
+ *
+ *  Copyright (c) 2019, Alberto Sottile
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *      * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *      * Neither the name of "darkdetect" nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL "Alberto Sottile" BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  Python
+ *  ======
+ *  https://docs.python.org/3/license.html
+ *
+ *  1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
+ *     the Individual or Organization ("Licensee") accessing and otherwise using Python
+ *     3.12.5 software in source or binary form and its associated documentation.
+ *
+ *  2. Subject to the terms and conditions of this License Agreement, PSF hereby
+ *     grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+ *     analyze, test, perform and/or display publicly, prepare derivative works,
+ *     distribute, and otherwise use Python 3.12.5 alone or in any derivative
+ *     version, provided, however, that PSF's License Agreement and PSF's notice of
+ *     copyright, i.e., "Copyright © 2001-2023 Python Software Foundation; All Rights
+ *     Reserved" are retained in Python 3.12.5 alone or in any derivative version
+ *     prepared by Licensee.
+ *
+ *  3. In the event Licensee prepares a derivative work that is based on or
+ *     incorporates Python 3.12.5 or any part thereof, and wants to make the
+ *     derivative work available to others as provided herein, then Licensee hereby
+ *     agrees to include in any such work a brief summary of the changes made to Python
+ *     3.12.5.
+ *
+ *  4. PSF is making Python 3.12.5 available to Licensee on an "AS IS" basis.
+ *     PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
+ *     EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
+ *     WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
+ *     USE OF PYTHON 3.12.5 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+ *
+ *  5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.12.5
+ *     FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+ *     MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.12.5, OR ANY DERIVATIVE
+ *     THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+ *
+ *  6. This License Agreement will automatically terminate upon a material breach of
+ *     its terms and conditions.
+ *
+ *  7. Nothing in this License Agreement shall be deemed to create any relationship
+ *     of agency, partnership, or joint venture between PSF and Licensee.  This License
+ *     Agreement does not grant permission to use PSF trademarks or trade name in a
+ *     trademark sense to endorse or promote products or services of Licensee, or any
+ *     third party.
+ *
+ *  8. By copying, installing or otherwise using Python 3.12.5, Licensee agrees
+ *     to be bound by the terms and conditions of this License Agreement.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#   include <Windows.h>
+#   include <winrt/Windows.UI.ViewManagement.h>
+#elif __APPLE__ || __linux__
+#   include <sys/types.h>
+#   include <sys/stat.h>
+#   include <unistd.h>
+#endif
+
+namespace breeze_stylesheets
+{
+    // we need a lot of optional strings
+    using _optstring = ::std::optional<::std::string>;
+
+    /// @brief An enumeration of valid values for a theme
+    enum class theme : int32_t
+    {
+        dark = 0,
+        light = 1,
+        unknown = 2,
+    };
+
+    /// @brief Determine if the color is bright as a quick estimate.
+    /// @param r The red value, from [0, 255].
+    /// @param g The green value, from [0, 255].
+    /// @param b The blue value, from [0, 255].
+    /// @return If the color is perceived as light.
+    inline bool
+    is_light_color(int r, int g, int b)
+    {
+        return (((5 * g) + (2 * r) + b) > (8 * 128));
+    }
+
+    /// @brief Split a string by a given delimiter.
+    /// @param value The string to split.
+    /// @param delimiter The delimiter to split on.
+    /// @return The split string.
+    inline ::std::vector<::std::string>
+    _split(::std::string value, char delimiter)
+    {
+        ::std::vector<::std::string> result;
+        ::std::size_t start = 0;
+        auto end = value.find(delimiter);
+        while (end != ::std::string::npos)
+        {
+            result.emplace_back(value.substr(start, end - start));
+            start = end + 1;
+            end = value.find(delimiter, start);
+        }
+
+        return result;
+    }
+
+    /// @brief Convert a string to lowercase, ASCII only (works for ASCII-extended scripts like UTF-8).
+    /// @param c The character to transform.
+    /// @return The character transformed to lowercase.
+    inline char
+    _to_ascii_lowercase(char c)
+    {
+        return (c <= 'Z' && c >= 'A') ? c - ('Z' - 'z') : c;
+    }
+
+    #if __APPLE__ || __linux__
+
+    /// @brief Determine if the file is an executable.
+    /// @param path The full path to the file.
+    /// @return If the file at the path is an executable.
+    inline bool
+    _is_executable_file(const ::std::string &path)
+    {
+        struct stat sb;
+        return (stat(path.c_str(), &sb) == 0) && S_ISREG(sb.st_mode) && (access(path.c_str(), X_OK) == 0);
+    }
+
+    /// @brief Determine if an executable exists along the path and return it if it does.
+    ///
+    /// POSIX-like operating systems don't have to worry about registered extensions like
+    /// Windows does.
+    ///
+    /// @param name The basename of the executable to look for.
+    /// @return The full path to the executable, if it exists.
+    inline _optstring
+    _which(const ::std::string &name)
+    {
+        // get our environment path, if it doesn't exist, force it on the path
+        char const *const c_path = getenv("PATH");
+        const ::std::string path = c_path != nullptr ? c_path : "";
+        if (path.empty())
+        {
+            if (_is_executable_file(name))
+            {
+                ::std::filesystem::path full_path = name;
+                return ::std::filesystem::absolute(full_path).string();
+            }
+            else
+                return ::std::nullopt;
+        }
+
+        // have a path, split our entries and go from there
+        const char pathsep = ':';
+        auto paths = _split(path, pathsep);
+        for (auto const &path : paths)
+        {
+            ::std::filesystem::path directory = path;
+            auto full_path = directory / name;
+            if (_is_executable_file(full_path.string()))
+                return ::std::filesystem::absolute(full_path).string();
+        }
+
+        return ::std::nullopt;
+    }
+
+    /// @brief Run a given command and return the output.
+    /// @param cmd The commands to run.
+    /// @return The output from the command.
+    ::std::tuple<_optstring, int>
+    _run_command(const ::std::string &cmd)
+    {
+        const ::std::size_t buffer_size = 1024;
+        ::std::array<char, buffer_size> buffer;
+        ::std::string result;
+
+        auto pipe = ::popen(cmd.c_str(), "r");
+        if (!pipe)
+            throw ::std::runtime_error("popen() failed!");
+        try
+        {
+            while (::fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr)
+            {
+                result += buffer.data();
+            }
+            auto code = ::pclose(pipe);
+            return ::std::make_tuple(result, code);
+        }
+        catch(...)
+        {
+            auto code = ::pclose(pipe);
+            return ::std::make_tuple(::std::nullopt, code);
+        }
+    }
+
+    #endif
+
+    #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+
+    using UISettings = winrt::Windows::UI::ViewManagement::UISettings;
+    using UIColorType = winrt::Windows::UI::ViewManagement::UIColorType;
+
+    // major, minor, build, platform, SP major, SP minor
+    using _winversion = ::std::tuple<int32_t, int32_t, int32_t, int32_t, int32_t, int32_t>;
+
+    /// @brief Get the error message from a code.
+    /// @param code The error code, optionally from `GetLastError`.
+    /// @return The descriptive message of the error code.
+    inline _optstring
+    _get_error(LSTATUS code)
+    {
+        if (code == ERROR_SUCCESS)
+            return ::std::nullopt;
+
+        LPSTR buffer = nullptr;
+        auto flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
+        auto lang = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
+        ::std::size_t size = FormatMessageA(flags, nullptr, code, lang, reinterpret_cast<LPSTR>(&buffer), 0, nullptr);
+
+        ::std::string message(buffer, size);
+        LocalFree(buffer);
+        return message;
+    }
+
+    /// @brief Get a DWORD registry key value.
+    /// @param key The registry HKEY location.
+    /// @param name The name of the registry value.
+    /// @return The value of the registry key.
+    inline DWORD
+    _get_dword_key(HKEY key, const ::std::wstring &name)
+    {
+        DWORD size(sizeof(DWORD));
+        DWORD result(0);
+        auto code = ::RegQueryValueExW(key, name.c_str(), 0, nullptr, reinterpret_cast<LPBYTE>(&result), &size);
+        if (code == ERROR_SUCCESS)
+            return result;
+        throw new ::std::runtime_error(_get_error(code).value());
+    }
+
+    /// @brief Get a string registry key value.
+    /// @param key The registry HKEY location.
+    /// @param name The name of the registry value.
+    /// @return The value of the registry key.
+    inline ::std::wstring
+    _get_string_key(HKEY key, const ::std::wstring &name)
+    {
+        WCHAR buffer[512];
+        DWORD size(sizeof(buffer));
+        auto code = ::RegQueryValueExW(key, name.c_str(), 0, nullptr, reinterpret_cast<LPBYTE>(buffer), &size);
+        if (code == ERROR_SUCCESS)
+            return ::std::wstring(buffer);
+        throw new ::std::runtime_error(_get_error(code).value());
+    }
+
+    /// @brief Open an HKEY from an initial starting point.
+    /// @param initial The initial HKEY, such as HKEY_LOCAL_MACHINE.
+    /// @param path The path relative to that HKEY, such as L"Software\\Microsoft".
+    /// @return The opened hkey.
+    inline HKEY
+    _open_hkey(HKEY initial, const ::std::wstring& path)
+    {
+        HKEY key;
+        auto code = ::RegOpenKeyExW(initial, path.c_str(), 0, KEY_READ, &key);
+        if (code != EXIT_SUCCESS)
+            throw new ::std::runtime_error(_get_error(code).value());
+        return key;
+    }
+
+    // NOTE: Windows support is based off of:
+    //  https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/ui/apply-windows-themes#know-when-dark-mode-is-enabled
+    //
+    // This requires linking against `Advapi32`.
+
+    /// @brief Return info about the running version of Windows as a named tuple.
+    ///
+    /// The members are named: major, minor, build, platform, service_pack,
+    /// service_pack_major, service_pack_minor, suite_mask, product_type and
+    /// platform_version. For backward compatibility, only the first 5 items
+    /// are available by indexing. All elements are numbers, except
+    /// service_pack and platform_type which are strings, and platform_version
+    /// which is a 3-tuple. Platform is always 2. Product_type may be 1 for a
+    /// workstation, 2 for a domain controller, 3 for a server.
+    /// Platform_version is a 3-tuple containing a version number that is
+    /// intended for identifying the OS rather than feature detection.
+    /// [clinic start generated code]*/
+    ///
+    /// This is taken from CPython's implementation.
+    ///
+    /// @return The windows version a multi-item tuple.
+    inline _winversion
+    _get_winversion()
+    {
+        // NOTE: We can't use `GetVersionExW` because this will depend on a manifest,
+        // which could return 6 or 10 depending on the scenario for the major version
+        // which is exactly what we **DON'T** want. We also cannot use `GetFileVersionInfoSizeExW`
+        // for a library version since the build versions will differ **slightly**. Nor
+        // do we want to require access to the Windows Desktop Kit for `RtlGetVersion`, so
+        // the simplest solution is just to use the registry.
+        HKEY current = _open_hkey(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion");
+        HKEY platform = _open_hkey(HKEY_LOCAL_MACHINE, L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0");
+        auto major = _get_dword_key(current, L"CurrentMajorVersionNumber");
+        auto minor = _get_dword_key(current, L"CurrentMinorVersionNumber");
+        auto build = _get_string_key(current, L"CurrentBuildNumber");
+        auto platformId = _get_dword_key(platform, L"Platform Specific Field 1");
+
+        // NOTE: We ignore the service pack information.
+        return ::std::make_tuple(
+            int32_t(major),
+            int32_t(minor),
+            std::stoi(build),
+            int32_t(platformId),
+            int32_t(0),
+            int32_t(0)
+        );
+    }
+
+    /// @brief Get the current system theme. This requires Windows 10+.
+    /// @return The type of the system theme.
+    inline ::breeze_stylesheets::theme
+    get_theme()
+    {
+        try
+        {
+            HKEY key;
+            auto personalize = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+            auto code = RegOpenKeyExW(HKEY_CURRENT_USER, personalize, 0, KEY_READ, &key);
+            if (code != EXIT_SUCCESS)
+                throw new ::std::runtime_error(_get_error(code).value());
+            auto use_light = _get_dword_key(key, L"AppsUseLightTheme");
+            return static_cast<::breeze_stylesheets::theme>(use_light);
+        }
+        catch(...)
+        {
+            /**
+             * some headless Windows instances (e.g. GitHub Actions or Docker images) do not have this key
+             * this is also not present if the user has never set the value. however, more recent Windows
+             * installs will have this, starting at `10.0.10240.0`:
+             *   https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/ui/apply-windows-themes#know-when-dark-mode-is-enabled
+             *
+             * Note that the documentation is inverted: if the foreground is light, we are using DARK mode.
+             */
+            auto winver = _get_winversion();
+            _winversion min_version = ::std::make_tuple(10, 0, 10240, 0, 0, 0);
+            if (winver < min_version)
+                return theme::unknown;
+
+            auto settings = UISettings();
+            auto foreground = settings.GetColorValue(UIColorType::Foreground);
+            // NOTE: a light foreground means a dark theme
+            auto light_foreground = is_light_color(foreground.R, foreground.G, foreground.B);
+            return light_foreground ? ::breeze_stylesheets::theme::dark : ::breeze_stylesheets::theme::light;
+        }
+    }
+
+    #elif __APPLE__
+    #   error "macOS not yet supported."
+    #elif __linux__
+
+    /// @brief Get the current system theme. This requires Windows 10+.
+    /// @return The type of the system theme.
+    inline ::breeze_stylesheets::theme
+    get_theme()
+    {
+        if (!_which("gsettings").has_value())
+            throw new ::std::runtime_error("Cannot find gsettings...");
+
+        // using the freedesktop specifications for checking dark mode
+        // this will return something like `prefer - dark`, which is the true value.
+        // valid values are 'default', 'prefer-dark', 'prefer-light'.
+        const ::std::string command = "gsettings get org.gnome.desktop.interface ";
+        auto [stdout, code] = ::breeze_stylesheets::_run_command(command + "color-scheme");
+        if (code != EXIT_SUCCESS)
+        {
+            // NOTE: We always assume this is due to invalid key, which might not be true
+            // since we don't check if gsettings exists first.
+            // if not found then trying older gtk-theme method
+            // this relies on the theme not lying to you : if the theme is dark, it ends in `- dark`.
+            auto [stdout, code] = ::breeze_stylesheets::_run_command(command + "gtk-theme");
+        }
+
+        if (code != EXIT_SUCCESS || !stdout.has_value())
+            throw new ::std::runtime_error("Unable to get response for the current system theme.");
+
+        auto value = stdout.value();
+        ::std::transform(value.begin(), value.end(), value.begin(), _to_ascii_lowercase);
+        auto is_dark = value.find("-dark") != ::std::string::npos;
+        return is_dark ? ::breeze_stylesheets::theme::dark : ::breeze_stylesheets::theme::light;
+    }
+
+    #else
+    #   error "Have an unknown target platform: only Windows, macOS, and Linux are supported."
+    #endif
+
+    /// @brief Get if the current theme is a dark color.
+    /// @return If the current theme is a dark color.
+    inline bool
+    is_dark()
+    {
+        return ::breeze_stylesheets::get_theme() == ::breeze_stylesheets::theme::dark;
+    }
+
+    /// @brief Get if the current theme is a light color.
+    /// @return If the current theme is a light color.
+    inline bool
+    is_light()
+    {
+        return ::breeze_stylesheets::get_theme() == ::breeze_stylesheets::theme::light;
+    }
+}

--- a/example/breeze_theme.py
+++ b/example/breeze_theme.py
@@ -1,0 +1,532 @@
+'''
+    breeze_theme
+    ============
+
+    Detect if the system theme is dark. This is taken and modified from:
+        https://github.com/albertosottile/darkdetect
+
+    The files have been modified to be merged into a single file and add
+    support for Qt6.5 dark detection. This is distributed under a
+    3-clause BSD license.
+
+    ---
+
+    Copyright (c) 2019, Alberto Sottile
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+        * Neither the name of "darkdetect" nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL "Alberto Sottile" BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+
+import typing
+import ctypes
+import ctypes.util
+import enum
+import os
+import platform
+import shutil
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+CallbackFn: typing.TypeAlias = typing.Callable[['Theme'], None]
+ThemeFn: typing.TypeAlias = typing.Callable[[], 'Theme']
+ListenerFn: typing.TypeAlias = typing.Callable[[CallbackFn], None]
+
+
+class Theme(enum.IntEnum):
+    '''The list of valid themes.'''
+
+    DARK = 0
+    LIGHT = 1
+    UNKNOWN = 2
+
+    @staticmethod
+    def from_string(value: str | None) -> 'Theme':
+        '''Initialize the enumeration from value.'''
+
+        # NOTE: This is for Py3.10 and earlier support.
+        if value is None or not value:
+            return Theme.UNKNOWN
+        value = value.lower()
+        if value == 'dark':
+            return Theme.DARK
+        elif value == 'light':
+            return Theme.LIGHT
+        raise ValueError(f'Got an invalid theme value of "{value}".')
+
+    def to_string(self) -> str:
+        '''Serialize the theme to string.'''
+
+        # NOTE: This is for Py3.10 and earlier support.
+        if self == Theme.DARK:
+            return 'Dark'
+        elif self == Theme.LIGHT:
+            return 'Light'
+        elif self == Theme.UNKNOWN:
+            return 'Unknown'
+        raise ValueError(f'Got an invalid theme value of "{self}".')
+
+
+def is_light_color(r: int, g: int, b: int) -> bool:
+    '''
+    Determine if the color is bright as a quick estimate from RGB.
+
+    Args:
+        r: The red value, from [0, 255].
+        g: The green value, from [0, 255].
+        b: The blue value, from [0, 255].
+
+    Returns:
+        If the color is perceived as light.
+    '''
+    return (((5 * g) + (2 * r) + b) > (8 * 128))
+
+# region windows
+
+
+def _theme_windows() -> Theme:
+    '''Get the current theme, as light or dark, for the system on Windows.'''
+
+    from winreg import HKEY_CURRENT_USER, OpenKey, QueryValueEx
+
+    # In HKEY_CURRENT_USER, get the Personalisation Key.
+    try:
+        key = OpenKey(HKEY_CURRENT_USER, 'Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize')
+        # In the Personalisation Key, get the AppsUseLightTheme subkey. This returns a tuple.
+        # The first item in the tuple is the result we want (0 or 1 indicating Dark Mode or Light Mode); the
+        # other value is the type of subkey e.g. DWORD, QWORD, String, etc.
+        use_light = QueryValueEx(key, 'AppsUseLightTheme')[0]
+    except FileNotFoundError:
+        # some headless Windows instances (e.g. GitHub Actions or Docker images) do not have this key
+        # this is also not present if the user has never set the value. however, more recent Windows
+        # installs will have this, starting at `10.0.10240.0`:
+        #   https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/ui/apply-windows-themes#know-when-dark-mode-is-enabled
+        #
+        # Note that the documentation is inverted: if the foreground is light, we are using DARK mode.
+        winver = sys.getwindowsversion()
+        if winver[:4] < (10, 0, 10240, 0):
+            return Theme.UNKNOWN
+        try:
+            # NOTE: This only works if we have the `winrt-Windows.UI.ViewManagement`
+            # and `winrt-Windows.UI` dependencies installed.
+            from winrt.windows.ui import viewmanagement  # pyright: ignore[reportMissingImports]
+
+            settings = viewmanagement.UISettings()
+            foreground = settings.get_color_value(viewmanagement.UIColorType.FOREGROUND)
+            use_light = int(not is_light_color(foreground.r, foreground.g, foreground.b))
+        except Exception:
+            return Theme.UNKNOWN
+
+    if use_light == 0:
+        return Theme.DARK
+    elif use_light == 1:
+        return Theme.LIGHT
+    return Theme.UNKNOWN
+
+
+def _listener_windows(callback: CallbackFn) -> None:
+    '''Register an event listener for dark/light theme changes.'''
+
+    import ctypes.wintypes  # pyright: ignore[reportMissingImports]
+
+    global _advapi32
+
+    if _advapi32 is None:
+        _advapi32 = _initialize_advapi32()
+    advapi32 = _advapi32
+
+    hkey = ctypes.wintypes.HKEY()
+    advapi32.RegOpenKeyExA(
+        ctypes.wintypes.HKEY(0x80000001),  # HKEY_CURRENT_USER
+        ctypes.wintypes.LPCSTR(b'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize'),
+        ctypes.wintypes.DWORD(),
+        ctypes.wintypes.DWORD(0x00020019),  # KEY_READ
+        ctypes.byref(hkey),
+    )
+
+    dwSize = ctypes.wintypes.DWORD(ctypes.sizeof(ctypes.wintypes.DWORD))
+    queryValueLast = ctypes.wintypes.DWORD()
+    queryValue = ctypes.wintypes.DWORD()
+    advapi32.RegQueryValueExA(
+        hkey,
+        ctypes.wintypes.LPCSTR(b'AppsUseLightTheme'),
+        ctypes.wintypes.LPDWORD(),
+        ctypes.wintypes.LPDWORD(),
+        ctypes.cast(ctypes.byref(queryValueLast), ctypes.wintypes.LPBYTE),
+        ctypes.byref(dwSize),
+    )
+
+    while True:
+        advapi32.RegNotifyChangeKeyValue(
+            hkey,
+            ctypes.wintypes.BOOL(True),
+            ctypes.wintypes.DWORD(0x00000004),  # REG_NOTIFY_CHANGE_LAST_SET
+            ctypes.wintypes.HANDLE(None),
+            ctypes.wintypes.BOOL(False),
+        )
+        advapi32.RegQueryValueExA(
+            hkey,
+            ctypes.wintypes.LPCSTR(b'AppsUseLightTheme'),
+            ctypes.wintypes.LPDWORD(),
+            ctypes.wintypes.LPDWORD(),
+            ctypes.cast(ctypes.byref(queryValue), ctypes.wintypes.LPBYTE),
+            ctypes.byref(dwSize),
+        )
+        if queryValueLast.value != queryValue.value:
+            queryValueLast.value = queryValue.value
+            callback(Theme.LIGHT if queryValue.value else Theme.DARK)
+
+
+def _initialize_advapi32() -> 'ctypes.WinDLL':
+    '''Initialize our advapi32 library.'''
+
+    import ctypes.wintypes  # pyright: ignore[reportMissingImports]
+
+    advapi32 = ctypes.windll.advapi32
+
+    # LSTATUS RegOpenKeyExA(
+    #     HKEY hKey,
+    #     LPCSTR lpSubKey,
+    #     DWORD ulOptions,
+    #     REGSAM samDesired,
+    #     PHKEY phkResult
+    # );
+    advapi32.RegOpenKeyExA.argtypes = (
+        ctypes.wintypes.HKEY,
+        ctypes.wintypes.LPCSTR,
+        ctypes.wintypes.DWORD,
+        ctypes.wintypes.DWORD,
+        ctypes.POINTER(ctypes.wintypes.HKEY),
+    )
+    advapi32.RegOpenKeyExA.restype = ctypes.wintypes.LONG
+
+    # LSTATUS RegQueryValueExA(
+    #     HKEY hKey,
+    #     LPCSTR lpValueName,
+    #     LPDWORD lpReserved,
+    #     LPDWORD lpType,
+    #     LPBYTE lpData,
+    #     LPDWORD lpcbData
+    # );
+    advapi32.RegQueryValueExA.argtypes = (
+        ctypes.wintypes.HKEY,
+        ctypes.wintypes.LPCSTR,
+        ctypes.wintypes.LPDWORD,
+        ctypes.wintypes.LPDWORD,
+        ctypes.wintypes.LPBYTE,
+        ctypes.wintypes.LPDWORD,
+    )
+    advapi32.RegQueryValueExA.restype = ctypes.wintypes.LONG
+
+    # LSTATUS RegNotifyChangeKeyValue(
+    #     HKEY hKey,
+    #     WINBOOL bWatchSubtree,
+    #     DWORD dwNotifyFilter,
+    #     HANDLE hEvent,
+    #     WINBOOL fAsynchronous
+    # );
+    advapi32.RegNotifyChangeKeyValue.argtypes = (
+        ctypes.wintypes.HKEY,
+        ctypes.wintypes.BOOL,
+        ctypes.wintypes.DWORD,
+        ctypes.wintypes.HANDLE,
+        ctypes.wintypes.BOOL,
+    )
+    advapi32.RegNotifyChangeKeyValue.restype = ctypes.wintypes.LONG
+
+    return advapi32
+
+
+_advapi32: typing.Optional['ctypes.WinDLL'] = None
+
+# endregion
+
+# region macos
+
+
+def macos_supported_version() -> bool:
+    '''Determine if we use a support macOS version.'''
+
+    # NOTE: This is typically 10.14.2 or 12.3
+    sysver = platform.mac_ver()[0]
+    major = int(sysver.split('.')[0])
+    if major < 10:
+        return False
+    elif major >= 11:
+        return True
+
+    # have a macOS10 version
+    minor = int(sysver.split('.')[1])
+    return minor >= 14
+
+
+def _theme_macos() -> Theme:
+    '''Get the current theme, as light or dark, for the system on macOS.'''
+
+    global _theme_macos_impl
+    if _theme_macos_impl is None:
+        _theme_macos_impl = _get_theme_macos()
+    return _theme_macos_impl()
+
+
+def _as_utf8(value: bytes | str) -> bytes:
+    '''Encode a value to UTF-8'''
+    return value if isinstance(value, bytes) else value.encode('utf-8')
+
+
+def _register_name(objc: ctypes.CDLL, name: bytes | str) -> None:
+    '''Register a name within our DLLs.'''
+    return objc.sel_registerName(_as_utf8(name))
+
+
+def _get_class(objc: ctypes.CDLL, name: bytes | str) -> 'ctypes._NamedFuncPointer':
+    '''Get a class by the registered name.'''
+    return objc.objc_getClass(_as_utf8(name))
+
+
+def _get_theme_macos() -> ThemeFn:
+    '''Create the theme callback for macOS.'''
+
+    # NOTE: We do this so we don't need imports at the global level.
+    try:
+        # macOS Big Sur+ use "a built-in dynamic linker cache of all system-provided libraries"
+        objc = ctypes.cdll.LoadLibrary('libobjc.dylib')
+    except OSError:
+        # revert to full path for older OS versions and hardened programs
+        objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('objc'))
+
+    # See https://docs.python.org/3/library/ctypes.html#function-prototypes for arguments description
+    msg_prototype = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
+    msg = msg_prototype(('objc_msgSend', objc), ((1, '', None), (1, '', None), (1, '', None)))
+
+    auto_release_pool = _get_class(objc, 'NSAutoreleasePool')
+    pool = msg(auto_release_pool, _register_name(objc, 'alloc'))
+    pool = msg(pool, _register_name(objc, 'init'))
+
+    user_defaults = _get_class(objc, 'NSUserDefaults')
+    std_user_defaults = msg(user_defaults, _register_name(objc, 'standardUserDefaults'))
+
+    ns_string = _get_class(objc, 'NSString')
+    key = msg(ns_string, _register_name(objc, "stringWithUTF8String:"), _as_utf8('AppleInterfaceStyle'))
+    appearance_ns = msg(std_user_defaults, _register_name(objc, 'stringForKey:'), ctypes.c_void_p(key))
+    appearance_c = msg(appearance_ns, _register_name(objc, 'UTF8String'))
+
+    out = ctypes.string_at(appearance_c) if appearance_c is not None else None
+    msg(pool, _register_name(objc, 'release'))
+    return Theme.from_string(out.decode('utf-8')) if out is not None else Theme.LIGHT
+
+
+def _listener_macos(callback: CallbackFn) -> None:
+    '''Register an event listener for dark/light theme changes.'''
+
+    try:
+        from Foundation import NSKeyValueObservingOptionNew as _  # noqa # pyright: ignore[reportMissingImports]
+    except (ImportError, ModuleNotFoundError):
+        raise RuntimeError('Missing the required Foundation modules: cannot listen.')
+
+    # now need to register a child event
+    path = Path(__file__)
+    command = [sys.executable, '-c', f'import {path.stem} as theme; theme._listen_child_macos()']
+    with subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        cwd=path.parent,
+    ) as process:
+        for line in process.stdout:
+            callback(Theme.from_string(line.strip()))
+
+
+def _listen_child_macos() -> None:
+    '''Create a confole event loop listing the macOS events.'''
+
+    # NOTE: We do this so we don't need imports at the global level.
+    try:
+        from Foundation import (  # pyright: ignore[reportMissingImports]
+            NSObject, NSKeyValueObservingOptionNew, NSKeyValueChangeNewKey, NSUserDefaults
+        )
+        from PyObjCTools import AppHelper  # pyright: ignore[reportMissingImports]
+    except ModuleNotFoundError:
+        raise RuntimeError('Missing the required Foundation modules: cannot listen.')
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    class Observer(NSObject):
+        def observeValueForKeyPath_ofObject_change_context_(
+            self, path, object, changeDescription, context
+        ):
+            _ = path
+            _ = object
+            _ = context
+            result = changeDescription[NSKeyValueChangeNewKey]
+            try:
+                value = 'Light' if result is None else result
+                print(value, flush=True)
+            except IOError:
+                os._exit(1)
+
+    # keep a reference alive after installing
+    observer = Observer.new()
+    defaults = NSUserDefaults.standardUserDefaults()
+    defaults.addObserver_forKeyPath_options_context_(
+        observer,
+        'AppleInterfaceStyle',
+        NSKeyValueObservingOptionNew,
+        0,
+    )
+
+    AppHelper.runConsoleEventLoop()
+
+
+_theme_macos_impl: ThemeFn | None = None
+
+# endregion
+
+# region linux
+
+
+def _theme_linux() -> Theme:
+    '''Get the current theme, as light or dark, for the system on Linux OSes.'''
+
+    try:
+        _, stdout = _get_gsettings_schema()
+    except Exception:
+        return Theme.LIGHT
+
+    # we have a string, now remove start and end quote
+    value = stdout.lower().strip()[1:-1]
+    return Theme.DARK if '-dark' in value.lower() else Theme.LIGHT
+
+
+def _listener_linux(callback: CallbackFn) -> None:
+    '''Register an event listener for dark/light theme changes.'''
+
+    gsettings = _get_gsettings()
+    schema, _ = _get_gsettings_schema()
+    command = [gsettings, 'monitor', 'org.gnome.desktop.interface', schema]
+    # this has rhe same restrictions as above
+    with subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True) as process:
+        for line in process.stdout:
+            value = line.removeprefix(f"{schema}: '").removesuffix("'")
+            callback(Theme.DARK if '-dark' in value.lower() else Theme.LIGHT)
+
+
+def _get_gsettings_schema() -> tuple[str, str]:
+    '''Get the schema to use when monitoring via gsettings.'''
+    # This follows the gsettings followed here:
+    #   https://github.com/GNOME/gsettings-desktop-schemas/blob/master/schemas/org.gnome.desktop.interface.gschema.xml.in
+
+    gsettings = _get_gsettings()
+    command = [gsettings, 'get', 'org.gnome.desktop.interface']
+    # using the freedesktop specifications for checking dark mode
+    # this will return something like `prefer-dark`, which is the true value.
+    #   valid values are 'default', 'prefer-dark', 'prefer-light'.
+    process = subprocess.run(command + ['color-scheme'], capture_output=True)
+    if process.returncode == 0:
+        return ('color-scheme', process.stdout.decode('utf-8'))
+    elif b'No such key' not in process.stderr:
+        raise RuntimeError('Unable to get our color-scheme from our gsettings.')
+
+    # if not found then trying older gtk-theme method
+    # this relies on the theme not lying to you: if the theme is dark, it ends in `-dark`.
+    process = subprocess.run(command + ['gtk-theme'], capture_output=True)
+    process.check_returncode()
+    return ('gtk-theme', process.stdout.decode('utf-8'))
+
+
+def _get_gsettings() -> str:
+    '''Get the gsettings tool to determine the theme color.'''
+
+    # NOTE: gsettings means GNU, it is desktop-environment generic.
+
+    global _gsettings
+
+    if _gsettings is None:
+        _gsettings = shutil.which('gsettings')
+    if _gsettings is None:
+        raise RuntimeError('Unable to find gsettings to determine if dark mode is used.')
+    return _gsettings
+
+
+_gsettings: str | None = None
+
+# endregion
+
+# region dummy
+
+
+def _theme_dummy() -> Theme:
+    '''Get the current theme, as light or dark, for the system (always unknown).'''
+    return Theme.UNKNOWN
+
+
+def _listener_dummy(callback: CallbackFn) -> None:
+    '''Register an event listener for dark/light theme changes (always unimplemented).'''
+    _ = callback
+
+# endregion
+
+
+def theme() -> Theme:
+    '''Get the current theme, as light or dark, for the system.'''
+    return _theme()
+
+
+def is_dark() -> bool:
+    '''Get if the current theme is a dark color.'''
+    return theme() == Theme.DARK
+
+
+def is_light() -> bool:
+    '''Get if the current theme is a light color.'''
+    return theme() == Theme.LIGHT
+
+
+def listener(callback: CallbackFn) -> None:
+    '''Register an event listener for dark/light theme changes.'''
+    _listener(callback)
+
+
+def register_functions() -> tuple[ThemeFn, ListenerFn]:
+    '''Register our global functions for our themes and listeners.'''
+
+    if sys.platform == 'darwin' and macos_supported_version():
+        return (_theme_macos, _listener_macos)
+    elif sys.platform == 'win32' and platform.release().isdigit() and int(platform.release()) >= 10:
+        # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER.
+        # The getwindowsversion method returns a tuple. The third item is the build number
+        # that we can use to check if the user has a new enough version of Windows.
+        winver = int(platform.version().split('.')[2])
+        if winver >= 14393:
+            return (_theme_windows, _listener_windows)
+        else:
+            return (_theme_dummy, _listener_dummy)
+    elif sys.platform == "linux":
+        return (_theme_linux, _listener_linux)
+    else:
+        return (_theme_dummy, _listener_dummy)
+
+
+# register these callbacks once
+_theme, _listener = register_functions()

--- a/example/shared.py
+++ b/example/shared.py
@@ -88,7 +88,7 @@ def parse_args(parser):
 
     # now we need to normalize our theme
     if args.stylesheet.startswith('auto'):
-        theme = breeze_theme.theme()
+        theme = breeze_theme.get_theme()
         if theme == breeze_theme.Theme.DARK:
             args.stylesheet = args.stylesheet.replace('auto', 'dark', 1)
         elif theme == breeze_theme.Theme.LIGHT:

--- a/example/standard_icons.py
+++ b/example/standard_icons.py
@@ -186,7 +186,7 @@ class Ui:
             'SP_DialogIgnoreButton',
             'SP_RestoreDefaultsButton',
         ]
-        if shared.get_version(args) >= (6, 3, 0):
+        if compat.QT_VERSION >= (6, 3, 0):
             default_icons.append('SP_TabCloseButton')
         add_standard_buttons(self, self.page2, default_icons)
 

--- a/vcs.py
+++ b/vcs.py
@@ -16,17 +16,216 @@ import sys
 
 home = os.path.dirname(os.path.realpath(__file__))
 
-GITIGNORE_ENTRIES = [
+# Based off of:
+#   https://github.com/github/gitignore/blob/main/Python.gitignore
+PYTHON_GITIGNORE = '''
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+'''
+
+# Based off of:
+#   https://github.com/github/gitignore/blob/main/C%2B%2B.gitignore
+CPP_GITIGNORE = '''
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+'''
+
+EXTRAS_GITIGNORE = [
     # Comments
     '# NOTE: this file is auto-generated via `git.py`',
     '# DO NOT MANUALLY EDIT THIS FILE.',
-    # Ignore all compiled bytecode.
-    '__pycache__',
-    '*.pyc',
-    # Ignore all resource files except `breeze.qrc`.
-    '*.qrc',
-    '!breeze.qrc',
-    'venv',
+    # extra entries
+    'TODO.md',
 ]
 
 
@@ -107,7 +306,7 @@ def write_gitignore(entries):
     '''Write to ignore ignore file using the provided entries.'''
 
     with open(os.path.join(home, '.gitignore'), 'w') as file:
-        file.write('\n'.join(entries) + '\n')
+        file.write(f'{"\n".join(entries)}\n{PYTHON_GITIGNORE}\n{CPP_GITIGNORE}\n')
 
 
 def main(argv=None):
@@ -144,7 +343,7 @@ def main(argv=None):
         return 0
 
     # Update our gitignore entries, and write to file.
-    gitignore_entries = list(GITIGNORE_ENTRIES)
+    gitignore_entries = list(EXTRAS_GITIGNORE)
     if args.no_track_dist:
         gitignore_entries += ['dist/', 'resources/']
     write_gitignore(gitignore_entries)


### PR DESCRIPTION
This provides C++ and Python code samples to auto-detect the current system theme on Windows, macOS, and Linux, and adjust the Qt theme accordingly. For example, with this you can use `auto-purple` and the theme will select `light-purple` or `dark-purple` accordingly.