### PR TITLE
Add installation of Git hooks.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
         "*.svg.in": "xml",
         "stdexcept": "cpp"
     },
-    "cmake.ignoreCMakeListsMissing": true
+    "cmake.ignoreCMakeListsMissing": true,
+    "python.REPL.enableREPLSmartSend": false
 }

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -9,6 +9,15 @@ set -eux pipefail
 scripts_home="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 project_home="$(dirname "${scripts_home}")"
 cd "${project_home}"
+# shellcheck source=/dev/null
+. "${scripts_home}/shared.sh"
 
-isort ./*.py example/*.py example/**/*.py
-black --config pyproject.toml example/ ./*.py
+# unless we manually provide an override, use whatever's
+# on the path by default.
+if ! is-set PYTHON; then
+    isort ./*.py example/*.py example/**/*.py
+    black --config pyproject.toml example/ ./*.py
+else
+    ${PYTHON} -m isort ./*.py example/*.py example/**/*.py
+    ${PYTHON} -m black --config pyproject.toml example/ ./*.py
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,10 +8,18 @@ set -eux pipefail
 scripts_home="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 project_home="$(dirname "${scripts_home}")"
 cd "${project_home}"
+# shellcheck source=/dev/null
+. "${scripts_home}/shared.sh"
 
 # run our python lint checks
-pylint ./*.py example/*.py example/**/*.py
-pyright example/breeze_theme.py
-flake8
-
-# run our C++ lint checks
+# unless we manually provide an override, use whatever's
+# on the path by default.
+if ! is-set PYTHON; then
+    pylint ./*.py example/*.py example/**/*.py
+    pyright example/breeze_theme.py
+    flake8
+else
+    ${PYTHON} -m pylint ./*.py example/*.py example/**/*.py
+    ${PYTHON} -m pyright example/breeze_theme.py
+    ${PYTHON} -m flake8
+fi


### PR DESCRIPTION
Add scripts to install or uninstall any Git hooks, currently used for pre-commit hooks. The generated precommit hook does linting, formatting, and tests the script can run basic tests.

```bash

#!/usr/bin/env bash
#
# A custom Git hook.

set -eux pipefail

hooks_home="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
git_home="$(dirname "${hooks_home}")"
project_home="$(dirname "${git_home}")"

scripts/lint.sh
scripts/fmt.sh
scripts/configure.sh
```