### PR TITLE
Fix theme detection builds on Windows.

### DIFF
--- a/.github/workflows/theme.yml
+++ b/.github/workflows/theme.yml
@@ -56,5 +56,5 @@ jobs:
       run: |
         mkdir dist -ErrorAction SilentlyContinue
         cd dist
-        cl ..\scripts\test_theme.cpp /std:c++17 /EHsc /link Advapi32.lib OleAut32.lib
+        cl ..\scripts\test_theme.cpp /std:c++20 /EHsc /link Advapi32.lib OleAut32.lib RuntimeObject.lib
         .\test_theme.exe

--- a/example/detect/system_theme.hpp
+++ b/example/detect/system_theme.hpp
@@ -6,7 +6,8 @@
  *
  *  This code has been minimally tested but should be useful on most platforms.
  *  This makes extensive use of C++17 features. On Windows, this requires adding
- *  `OleAut32.lib` and `Advapi32.lib` to the linker.
+ *  `OleAut32.lib` and `Advapi32.lib` to the linker. For 2.0 versions of winrt,
+ *  you will also need to add `RuntimeObject.lib` to the linker.
  *
  *  This currently supports:
  *  - Windows


### PR DESCRIPTION
This is due to `winrt/Windows.UI.ViewManagement.h` with the C++17 flag, which is no longer supported by new compilers. Migrating to C++20 works.